### PR TITLE
Implement HTML parser and unit tests

### DIFF
--- a/src/html_parser.py
+++ b/src/html_parser.py
@@ -1,0 +1,30 @@
+"""Simple HTML parser utility."""
+from typing import Any
+
+try:  # Try to use lxml for strict HTML parsing
+    from lxml import etree
+
+    def parse_html(html_content: str) -> Any:
+        """Parse HTML content and return the root element.
+
+        Raises:
+            ValueError: If the HTML is malformed.
+        """
+        try:
+            return etree.fromstring(html_content)
+        except etree.XMLSyntaxError as exc:
+            raise ValueError(f"Failed to parse HTML: {exc}") from exc
+
+except Exception:  # pragma: no cover - fallback if lxml is unavailable
+    import xml.etree.ElementTree as ET
+
+    def parse_html(html_content: str) -> Any:
+        """Parse HTML content using ElementTree as a fallback.
+
+        Raises:
+            ValueError: If the HTML is malformed.
+        """
+        try:
+            return ET.fromstring(html_content)
+        except ET.ParseError as exc:
+            raise ValueError(f"Failed to parse HTML: {exc}") from exc

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Sales Forecasting</title>
+</head>
+<body>
+</body>
+</html>

--- a/tests/test_html_parser.py
+++ b/tests/test_html_parser.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+# Ensure src package is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.html_parser import parse_html
+
+
+def test_parse_valid_html():
+    html_path = Path("templates/index.html")
+    content = html_path.read_text()
+    parsed = parse_html(content)
+    assert parsed is not None
+
+
+def test_parse_invalid_html():
+    malformed = "<html><head></head><body><p></html>"
+    with pytest.raises(ValueError):
+        parse_html(malformed)


### PR DESCRIPTION
## Summary
- Add basic `templates/index.html`
- Implement `parse_html` with lxml/ElementTree and error handling
- Test valid and malformed HTML parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68abacbb6584832889a8227b3ea67bca