### PR TITLE
Fix React 18 rendering API usage

### DIFF
--- a/advanced_sales_forecasting.html
+++ b/advanced_sales_forecasting.html
@@ -1948,7 +1948,9 @@
         };
 
         // 앱 렌더링
-        ReactDOM.render(<AdvancedSalesForecastingApp />, document.getElementById('root'));
+        const rootElement = document.getElementById('root');
+        const root = ReactDOM.createRoot(rootElement);
+        root.render(<AdvancedSalesForecastingApp />);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use `ReactDOM.createRoot` to mount AdvancedSalesForecastingApp

## Testing
- `npx --yes htmlhint advanced_sales_forecasting.html` *(fails: 403 Forbidden)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68abb3790e188328a4080ad40008c98f