### PR TITLE
Refactor prediction parameter handling in forecast useMemo

### DIFF
--- a/advanced_sales_forecasting.html
+++ b/advanced_sales_forecasting.html
@@ -1332,13 +1332,15 @@
             const predictions = useMemo(() => {
                 if (aggregatedData.length === 0) return [];
                 setIsLoading(true);
-                
+
                 try {
+
+                    const params = algorithmParameters[selectedAlgorithm];
 
                     const result = algorithms[selectedAlgorithm](
                         aggregatedData,
-                        parameters[selectedAlgorithm],
-                        parameters[selectedAlgorithm].forecast_length
+                        params,
+                        params.forecast_length
                     );
                     setTimeout(() => setIsLoading(false), 500);
                     return result;


### PR DESCRIPTION
## Summary
- Use `algorithmParameters` instead of `parameters` for prediction settings
- Introduce `params` helper for cleaner algorithm invocation

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_b_68abe7256c888328b3d81c79eba64a34