### PR TITLE
Fix JSX block in dark sales forecast page

### DIFF
--- a/dark_sales_forecaster.html
+++ b/dark_sales_forecaster.html
@@ -1459,4 +1459,49 @@
                                     
                                     <div className="grid" style={{gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))'}}>
                                         <div>
-                                            
+                                            <h4 className="font-bold text-blue-400 mb-2">🌙 다크모드 특징</h4>
+                                            <ul className="text-sm text-gray-300 space-y-1">
+                                                <li>• 어두운 UI로 눈의 피로 감소</li>
+                                                <li>• 대비 향상으로 데이터 가독성 증가</li>
+                                                <li>• 실시간 차트 업데이트</li>
+                                            </ul>
+                                        </div>
+                                        <div>
+                                            <h4 className="font-bold text-purple-400 mb-2">🚀 Pro 기능</h4>
+                                            <ul className="text-sm text-gray-300 space-y-1">
+                                                <li>• 고급 AI 알고리즘 지원</li>
+                                                <li>• 파라메터 실시간 튜닝</li>
+                                                <li>• CSV 결과 내보내기</li>
+                                            </ul>
+                                        </div>
+                                    </div>
+
+                                    <div className="mt-4 p-4 bg-gray-800 rounded-lg border-l-4 border-purple-500">
+                                        <h4 className="font-bold text-gray-100 mb-2">📋 CSV 파일 형식 예시</h4>
+                                        <div className="bg-gray-900 rounded p-3 text-xs font-mono">
+                                            year,month,country,product,sales<br/>
+                        2019,1,한국,제품A,150<br/>
+                        2019,1,한국,제품B,120<br/>
+                        2019,1,미국,제품A,280<br/>
+                        2020,1,한국,제품A,165<br/>
+                        ...
+                                        </div>
+                                        <p className="text-xs text-gray-400 mt-2">
+                                            <strong>필수 컬럼:</strong> year(연도), month(월), sales(매출)<br/>
+                                            <strong>선택 컬럼:</strong> country(국가), product(제품)
+                                        </p>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            );
+        };
+
+        // 앱 렌더링
+        ReactDOM.render(<DarkSalesForecastingApp />, document.getElementById('root'));
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Complete the Pro features section in `dark_sales_forecaster.html`
- Add CSV format example and finalize closing tags to resolve JSX parsing error

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68b05e7a29a483289a81bcd4f0c98776