### PR TITLE
Rename simulator and trim header padding

### DIFF
--- a/advanced_sales_forecasting.html
+++ b/advanced_sales_forecasting.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Advanced 매출 예측 시뮬레이터 Pro</title>
+    <title>Seegene 매출 예측 시뮬레이터</title>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
@@ -35,7 +35,7 @@
         .header {
             text-align: center;
             margin-bottom: 2rem;
-            padding: 2rem;
+            padding: 1.5rem;
             background: linear-gradient(135deg, #4F46E5 0%, #7C3AED 100%);
             border-radius: 1rem;
             color: white;
@@ -1573,7 +1573,7 @@
                     />
 
                     <div className="header">
-                        <h1><i className="fas fa-rocket"></i> Advanced 매출 예측 시뮬레이터 Pro</h1>
+                        <h1><i className="fas fa-rocket"></i> Seegene 매출 예측 시뮬레이터</h1>
                         <p>최신 AI 기술을 활용한 차세대 매출 예측 솔루션 - 파라메터 튜닝 지원</p>
                     </div>
 


### PR DESCRIPTION
## Summary
- Rebrand interface to "Seegene 매출 예측 시뮬레이터"
- Slightly reduce top header padding for a more compact layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b06cfd46c88328b6a27979d766c095