### PR TITLE
Fix truncated dark sales forecaster HTML

### DIFF
--- a/dark_sales_forecaster.html
+++ b/dark_sales_forecaster.html
@@ -1450,13 +1450,40 @@
                                     )}
                                 </div>
 
-                                {/* 기능 안내 */}
+                                {/* 파라미터 튜닝 가이드 */}
                                 <div className="card" style={{background: 'linear-gradient(135deg, rgba(30, 30, 50, 0.8) 0%, rgba(25, 25, 40, 0.8) 100%)'}}>
                                     <div className="card-header">
-                                        <i className="fas fa-star text-purple-600"></i>
-                                        <h2 className="card-title">다크모드 Pro 기능</h2>
+                                        <i className="fas fa-sliders-h text-purple-600"></i>
+                                        <h2 className="card-title">파라미터 튜닝 가이드</h2>
                                     </div>
-                                    
-                                    <div className="grid" style={{gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))'}}>
-                                        <div>
-                                            
+
+                                    <div className="space-y-4">
+                                        {Object.entries(algorithmInfo).map(([algKey, info]) => (
+                                            <div key={algKey}>
+                                                <h3 className="font-medium mb-2" style={{color: '#e2e8f0'}}>{info.name}</h3>
+                                                <ul className="text-sm text-gray-400 space-y-1">
+                                                    {Object.entries(info.parameters).map(([paramKey, config]) => (
+                                                        <li key={paramKey}>
+                                                            <span className="text-gray-200">
+                                                                {paramKey.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}: {defaultParameters[algKey][paramKey]}{config.suffix}
+                                                            </span>
+                                                            <span className="ml-2 text-gray-500">{config.description}</span>
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            );
+        };
+
+        // 앱 렌더링
+        ReactDOM.render(<DarkSalesForecastingApp />, document.getElementById('root'));
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace dark mode Pro feature card with parameter tuning guide
- list each algorithm's default parameters and descriptions

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68b06ae9b3088328a5d9ce05dcf843cf