### PR TITLE
Add cute favicon

### DIFF
--- a/advanced_sales_forecasting.html
+++ b/advanced_sales_forecasting.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Seegene 매출 예측 시뮬레이터</title>
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>

--- a/app.py
+++ b/app.py
@@ -2,9 +2,21 @@ from flask import Flask, send_file
 
 app = Flask(__name__)
 
+
 @app.route('/')
 def index():
     return send_file('advanced_sales_forecasting.html')
+
+
+@app.route('/favicon.svg')
+def favicon_svg():
+    return send_file('favicon.svg', mimetype='image/svg+xml')
+
+
+@app.route('/favicon.ico')
+def favicon_ico():
+    return send_file('favicon.svg', mimetype='image/svg+xml')
+
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=True)

--- a/dark_sales_forecaster.html
+++ b/dark_sales_forecaster.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Seegene 매출 예측 시뮬레이터</title>
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <circle cx="64" cy="64" r="64" fill="#ffc0cb"/>
+  <circle cx="44" cy="54" r="10" fill="#222222"/>
+  <circle cx="84" cy="54" r="10" fill="#222222"/>
+  <path d="M40 80 Q64 100 88 80" stroke="#222222" stroke-width="8" fill="none" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add SVG favicon and routes to serve it
- Include favicon reference in light and dark HTML templates

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0ffe15d84832887f974b8f496afc8