### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/dark_sales_forecaster.html
+++ b/dark_sales_forecaster.html
@@ -11,7 +11,12 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.10.0/dist/tf.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <style>
+    <style id="dark-theme">
+        :root {
+            --chart-text-color: #cbd5e1;
+            --chart-grid-color: rgba(255, 255, 255, 0.1);
+            --chart-title-color: #ffffff;
+        }
         * {
             margin: 0;
             padding: 0;
@@ -538,11 +543,508 @@
         ::-webkit-scrollbar-thumb:hover {
             background: rgba(168, 85, 247, 0.7);
         }
+            .theme-toggle {
+            position: fixed;
+            top: 1rem;
+            right: 1rem;
+            background: rgba(255, 255, 255, 0.1);
+            color: #ffffff;
+            border: none;
+            border-radius: 0.5rem;
+            padding: 0.5rem 0.75rem;
+            cursor: pointer;
+            font-size: 1.25rem;
+            z-index: 1000;
+        }
+    </style>
+    <style id="light-theme">
+        :root {
+            --chart-text-color: #374151;
+            --chart-grid-color: rgba(0, 0, 0, 0.1);
+            --chart-title-color: #1f2937;
+        }
+        /* 전체 스타일링 */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            color: #1a1a1a;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+        }
+
+        .app-container {
+            min-height: 100vh;
+            padding: 1rem;
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(10px);
+        }
+
+        .header {
+            text-align: center;
+            margin-bottom: 2rem;
+            padding: 1.5rem;
+            background: linear-gradient(135deg, #4F46E5 0%, #7C3AED 100%);
+            border-radius: 1rem;
+            color: white;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+        }
+
+        .header h1 {
+            font-size: 2.5rem;
+            margin-bottom: 0.5rem;
+            font-weight: 700;
+        }
+
+        .header p {
+            font-size: 1.1rem;
+            opacity: 0.9;
+        }
+
+        .container {
+            width: 100%;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .grid {
+            display: grid;
+            gap: 1.5rem;
+            grid-template-columns: 1fr 2fr;
+        }
+
+        @media (max-width: 1024px) {
+            .grid {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        /* 카드 스타일 */
+        .card {
+            background: white;
+            border-radius: 1rem;
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+            padding: 1.5rem;
+            margin-bottom: 1.5rem;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            transition: all 0.3s ease;
+        }
+
+        .card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
+        }
+
+        .card-header {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            margin-bottom: 1rem;
+            padding-bottom: 0.75rem;
+            border-bottom: 2px solid #f1f5f9;
+        }
+
+        .card-title {
+            font-size: 1.125rem;
+            font-weight: 600;
+            color: #1e293b;
+        }
+
+        /* 폼 요소 */
+        .form-group {
+            margin-bottom: 1rem;
+        }
+
+        .form-label {
+            display: block;
+            margin-bottom: 0.5rem;
+            font-weight: 500;
+            color: #374151;
+            font-size: 0.875rem;
+        }
+
+        .form-input, .form-select {
+            width: 100%;
+            padding: 0.75rem;
+            border: 2px solid #e5e7eb;
+            border-radius: 0.5rem;
+            font-size: 0.875rem;
+            transition: all 0.2s ease;
+            background: white;
+        }
+
+        .form-input:focus, .form-select:focus {
+            outline: none;
+            border-color: #4F46E5;
+            box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
+        }
+
+        .slider {
+            width: 100%;
+            height: 6px;
+            border-radius: 3px;
+            background: linear-gradient(to right, #e5e7eb, #4F46E5);
+            outline: none;
+            -webkit-appearance: none;
+            appearance: none;
+            transition: all 0.2s ease;
+        }
+
+        .slider::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            appearance: none;
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            background: #4F46E5;
+            cursor: pointer;
+            box-shadow: 0 2px 10px rgba(79, 70, 229, 0.3);
+            transition: all 0.2s ease;
+        }
+
+        .slider::-webkit-slider-thumb:hover {
+            transform: scale(1.1);
+            box-shadow: 0 4px 15px rgba(79, 70, 229, 0.4);
+        }
+
+        /* 버튼 */
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.75rem 1.5rem;
+            font-size: 0.875rem;
+            font-weight: 500;
+            border-radius: 0.5rem;
+            border: none;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            text-decoration: none;
+        }
+
+        .btn-primary {
+            background: linear-gradient(135deg, #4F46E5 0%, #7C3AED 100%);
+            color: white;
+        }
+
+        .btn-primary:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 4px 15px rgba(79, 70, 229, 0.3);
+        }
+
+        .btn-success {
+            background: linear-gradient(135deg, #10B981 0%, #059669 100%);
+            color: white;
+        }
+
+        .btn-success:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 4px 15px rgba(16, 185, 129, 0.3);
+        }
+
+        .btn-secondary {
+            background: #f8fafc;
+            color: #475569;
+            border: 1px solid #e2e8f0;
+        }
+
+        .btn-secondary:hover {
+            background: #f1f5f9;
+            transform: translateY(-1px);
+        }
+
+        .btn-reset {
+            background: #fef3c7;
+            color: #d97706;
+            border: 1px solid #fbbf24;
+            font-size: 0.75rem;
+            padding: 0.5rem 1rem;
+        }
+
+        .btn-reset:hover {
+            background: #fde68a;
+        }
+
+        /* 차트 */
+        .chart-container {
+            position: relative;
+            height: 400px;
+            width: 100%;
+            background: white;
+            border-radius: 0.75rem;
+            padding: 1rem;
+        }
+
+        /* 테이블 */
+        .table-container {
+            overflow-x: auto;
+            border-radius: 0.5rem;
+            border: 1px solid #e5e7eb;
+        }
+
+        .table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.875rem;
+        }
+
+        .table th {
+            background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+            padding: 0.75rem;
+            text-align: left;
+            font-weight: 600;
+            color: #374151;
+            border-bottom: 1px solid #e5e7eb;
+        }
+
+        .table td {
+            padding: 0.75rem;
+            border-bottom: 1px solid #f1f5f9;
+        }
+
+        .table tr:hover {
+            background: #f8fafc;
+        }
+
+        /* 통계 카드 */
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .stat-card {
+            background: linear-gradient(135deg, #fff 0%, #f8fafc 100%);
+            padding: 1.5rem;
+            border-radius: 0.75rem;
+            border: 1px solid #e2e8f0;
+            text-align: center;
+        }
+
+        .stat-value {
+            font-size: 1.875rem;
+            font-weight: 700;
+            margin-bottom: 0.25rem;
+        }
+
+        .stat-label {
+            font-size: 0.875rem;
+            color: #64748b;
+        }
+
+        /* 로딩 애니메이션 */
+        .loading {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            padding: 2rem;
+        }
+
+        .spinner {
+            width: 40px;
+            height: 40px;
+            border: 3px solid #f1f5f9;
+            border-top: 3px solid #4F46E5;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
+        /* 알고리즘 뱃지 */
+        .algorithm-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.25rem;
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .badge-basic {
+            background: #dbeafe;
+            color: #1d4ed8;
+        }
+
+        .badge-advanced {
+            background: #f3e8ff;
+            color: #7c3aed;
+        }
+
+        .badge-expert {
+            background: #fef3c7;
+            color: #d97706;
+        }
+
+        .badge-ai {
+            background: #10b981;
+            color: white;
+        }
+
+        /* 파라메터 조정 영역 */
+        .parameter-section {
+            background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+            padding: 1rem;
+            border-radius: 0.75rem;
+            margin-top: 1rem;
+            border: 1px solid #e2e8f0;
+        }
+
+        .parameter-grid {
+            display: grid;
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+
+        .parameter-item {
+            background: white;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            border: 1px solid #e5e7eb;
+        }
+
+        .parameter-label {
+            font-weight: 500;
+            font-size: 0.875rem;
+            color: #374151;
+            margin-bottom: 0.5rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .parameter-value {
+            color: #4F46E5;
+            font-weight: 600;
+        }
+
+        .parameter-description {
+            font-size: 0.75rem;
+            color: #6b7280;
+            margin-top: 0.25rem;
+        }
+
+        .algorithm-description {
+            background: linear-gradient(135deg, #eff6ff 0%, #f0f9ff 100%);
+            padding: 1rem;
+            border-radius: 0.75rem;
+            border-left: 4px solid #3b82f6;
+            margin-top: 1rem;
+        }
+
+        /* 유틸리티 */
+        .text-center { text-align: center; }
+        .text-right { text-align: right; }
+        .font-bold { font-weight: 700; }
+        .font-medium { font-weight: 500; }
+        .text-sm { font-size: 0.875rem; }
+        .text-xs { font-size: 0.75rem; }
+        .text-gray-600 { color: #4b5563; }
+        .text-gray-500 { color: #6b7280; }
+        .text-green-600 { color: #16a34a; }
+        .text-red-600 { color: #dc2626; }
+        .text-blue-600 { color: #2563eb; }
+        .text-purple-600 { color: #9333ea; }
+        .mb-2 { margin-bottom: 0.5rem; }
+        .mb-4 { margin-bottom: 1rem; }
+        .mt-2 { margin-top: 0.5rem; }
+        .mt-4 { margin-top: 1rem; }
+        .space-y-4 > * + * { margin-top: 1rem; }
+        .flex { display: flex; }
+        .items-center { align-items: center; }
+        .justify-between { justify-content: space-between; }
+        .gap-2 { gap: 0.5rem; }
+        .gap-4 { gap: 1rem; }
+
+        /* 반응형 */
+        @media (max-width: 768px) {
+            .header h1 {
+                font-size: 1.875rem;
+            }
+            
+            .stats-grid {
+                grid-template-columns: 1fr;
+            }
+            
+            .chart-container {
+                height: 300px;
+            }
+        }
+
+        /* 토스트 알림 */
+        .toast {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background: white;
+            border: 1px solid #e5e7eb;
+            border-radius: 0.5rem;
+            padding: 1rem;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            z-index: 1000;
+            transform: translateX(400px);
+            transition: transform 0.3s ease;
+        }
+
+        .toast.show {
+            transform: translateX(0);
+        }
+
+        .toast.success {
+            border-left: 4px solid #10b981;
+        }
+
+        .toast.error {
+            border-left: 4px solid #ef4444;
+        }
+        .theme-toggle {
+            position: fixed;
+            top: 1rem;
+            right: 1rem;
+            background: rgba(0, 0, 0, 0.1);
+            color: #1a1a1a;
+            border: none;
+            border-radius: 0.5rem;
+            padding: 0.5rem 0.75rem;
+            cursor: pointer;
+            font-size: 1.25rem;
+            z-index: 1000;
+        }
+
     </style>
 </head>
 <body>
+    <button id="theme-toggle" class="theme-toggle">☀️</button>
     <div id="root"></div>
-    
+
+        <script>
+        const toggleButton = document.getElementById('theme-toggle');
+        const darkTheme = document.getElementById('dark-theme');
+        const lightTheme = document.getElementById('light-theme');
+        lightTheme.disabled = true;
+        document.documentElement.setAttribute('data-theme', 'dark');
+        toggleButton.addEventListener('click', () => {
+            const isDark = !darkTheme.disabled;
+            darkTheme.disabled = isDark;
+            lightTheme.disabled = !isDark;
+            const newTheme = isDark ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-theme', newTheme);
+            toggleButton.textContent = isDark ? '🌙' : '☀️';
+            window.dispatchEvent(new Event('themeChange'));
+        });
+    </script>
+
     <script type="text/babel">
         const { useState, useEffect, useMemo, useRef, useCallback } = React;
 
@@ -605,15 +1107,30 @@
         const SalesChart = ({ data, predictions, showConfidenceInterval = true, isLoading = false }) => {
             const chartRef = useRef(null);
             const chartInstanceRef = useRef(null);
+            const [theme, setTheme] = useState('dark');
+
+            useEffect(() => {
+                const handleThemeChange = () => {
+                    setTheme(document.documentElement.getAttribute('data-theme') || 'dark');
+                };
+                window.addEventListener('themeChange', handleThemeChange);
+                handleThemeChange();
+                return () => window.removeEventListener('themeChange', handleThemeChange);
+            }, []);
 
             useEffect(() => {
                 if (!chartRef.current || isLoading) return;
 
                 const ctx = chartRef.current.getContext('2d');
-                
+
                 if (chartInstanceRef.current) {
                     chartInstanceRef.current.destroy();
                 }
+
+                const styles = getComputedStyle(document.documentElement);
+                const textColor = styles.getPropertyValue('--chart-text-color').trim();
+                const gridColor = styles.getPropertyValue('--chart-grid-color').trim();
+                const titleColor = styles.getPropertyValue('--chart-title-color').trim();
 
                 const allData = [...data, ...predictions];
                 const labels = allData.map(d => d.date);
@@ -621,11 +1138,11 @@
                 const predictedData = allData.map(d => d.type === 'predicted' ? d.sales : null);
 
                 const datasets = [
-                    {
-                        label: '실제 매출',
-                        data: actualData,
-                        borderColor: '#3b82f6',
-                        backgroundColor: 'rgba(59, 130, 246, 0.1)',
+                        {
+                            label: '실제 매출',
+                            data: actualData,
+                            borderColor: '#3b82f6',
+                            backgroundColor: 'rgba(59, 130, 246, 0.1)',
                         fill: false,
                         tension: 0.4,
                         pointRadius: 4,
@@ -704,7 +1221,7 @@
                                     weight: 'bold'
                                 },
                                 padding: 20,
-                                color: '#ffffff'
+                                color: titleColor
                             },
                             legend: {
                                 display: true,
@@ -712,7 +1229,7 @@
                                 labels: {
                                     padding: 20,
                                     usePointStyle: true,
-                                    color: '#cbd5e1'
+                                    color: textColor
                                 }
                             }
                         },
@@ -725,13 +1242,13 @@
                                     font: {
                                         weight: 'bold'
                                     },
-                                    color: '#cbd5e1'
+                                    color: textColor
                                 },
                                 grid: {
-                                    color: 'rgba(255, 255, 255, 0.1)'
+                                    color: gridColor
                                 },
                                 ticks: {
-                                    color: '#94a3b8'
+                                    color: textColor
                                 }
                             },
                             y: {
@@ -742,13 +1259,13 @@
                                     font: {
                                         weight: 'bold'
                                     },
-                                    color: '#cbd5e1'
+                                    color: textColor
                                 },
                                 grid: {
-                                    color: 'rgba(255, 255, 255, 0.1)'
+                                    color: gridColor
                                 },
                                 ticks: {
-                                    color: '#94a3b8'
+                                    color: textColor
                                 },
                                 beginAtZero: false
                             }
@@ -765,7 +1282,7 @@
                         chartInstanceRef.current.destroy();
                     }
                 };
-            }, [data, predictions, showConfidenceInterval, isLoading]);
+            }, [data, predictions, showConfidenceInterval, isLoading, theme]);
 
             if (isLoading) {
                 return <LoadingSpinner message="차트 생성 중..." />;


### PR DESCRIPTION
## Summary
- enable switching between dark and light styles on the dark sales forecaster page
- default to dark theme and update chart colors for better visibility in light mode

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68b10ecfdf048328998e2406ddbbf9eb