### PR TITLE
Fix syntax error in wavelet_arima script

### DIFF
--- a/dark_sales_forecaster.html
+++ b/dark_sales_forecaster.html
@@ -979,7 +979,6 @@
                         const slice = data.slice(start, idx + 1);
                         return slice.reduce((s, x) => s + x.sales, 0) / slice.length;
                     });
-<
 
                     const diffLevels = [smoothed];
                     for (let d = 0; d < arima_d; d++) {


### PR DESCRIPTION
## Summary
- remove stray angle bracket causing JSX parse error in wavelet_arima section of dark_sales_forecaster.html

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b6f7bbfbb0832896f34d8ec3aec396