### PR TITLE
Fix missing wavelet ARIMA predictions

### DIFF
--- a/dark_sales_forecaster.html
+++ b/dark_sales_forecaster.html
@@ -979,7 +979,6 @@
                         const slice = data.slice(start, idx + 1);
                         return slice.reduce((s, x) => s + x.sales, 0) / slice.length;
                     });
-<
 
                     const diffLevels = [smoothed];
                     for (let d = 0; d < arima_d; d++) {
@@ -994,8 +993,13 @@
 
                     for (let i = 1; i <= forecast_length; i++) {
                         const baseDiff = diffLevels[arima_d];
-                        const ar = arima_p ? baseDiff.slice(-arima_p).reduce((sum, v, idx) => sum + v * (arima_p - idx) / arima_p, 0) / arima_p : 0;
-                        const ma = arima_q ? errors.reduce((sum, v, idx) => sum + v * (arima_q - idx) / arima_q, 0) / arima_q : 0;
+                        const arTerms = baseDiff.slice(-arima_p);
+                        const ar = arima_p && arTerms.length
+                            ? arTerms.reduce((sum, v, idx) => sum + v * (arTerms.length - idx) / arTerms.length, 0) / arTerms.length
+                            : 0;
+                        const ma = arima_q
+                            ? errors.reduce((sum, v, idx) => sum + v * (errors.length - idx) / errors.length, 0) / errors.length
+                            : 0;
                         const nextDiff = ar + ma;
 
                         if (arima_q) {
@@ -1018,10 +1022,6 @@
                             date: `2025-${i.toString().padStart(2, '0')}`,
                             type: 'predicted'
                         });
-                        if (arima_q) {
-                            maTerms = [...maTerms.slice(-(arima_q - 1)), next - series[series.length - 1]];
-                        }
-                        series.push(next);
                     }
 
                     return predictions;


### PR DESCRIPTION
## Summary
- remove leftover moving-average term handling in `wavelet_arima` that referenced undefined variables and prevented predictions
- remove extraneous `<` after smoothed-data mapping in `wavelet_arima` script to restore valid JSX
- use actual available history when computing AR/MA components in wavelet ARIMA to avoid zeroing past values

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b6f7bbfbb0832896f34d8ec3aec396