### PR TITLE
feat: add popup for forecast start month

### DIFF
--- a/dark_sales_forecaster.html
+++ b/dark_sales_forecaster.html
@@ -1078,7 +1078,9 @@
                     let year = last.year;
                     let month = last.month + 1;
                     if (month > 12) { year += 1; month = 1; }
-                    setForecastStartMonth(`${year}-${month.toString().padStart(2, '0')}`);
+                    const defaultStart = `${year}-${month.toString().padStart(2, '0')}`;
+                    const userInput = window.prompt('예측 시작월을 입력하세요 (YYYY-MM)', defaultStart);
+                    setForecastStartMonth(userInput || defaultStart);
                 }
             }, [aggregatedData, forecastStartMonth]);
 


### PR DESCRIPTION
## Summary
- prompt user for forecast start month when data loads

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68b7736b723483289b8b0f5f643b313c