### PR TITLE
style: set start month picker icon white

### DIFF
--- a/dark_sales_forecaster.html
+++ b/dark_sales_forecaster.html
@@ -167,6 +167,11 @@
             color: #ffffff;
         }
 
+        /* Ensure calendar icon is visible on dark backgrounds */
+        .form-input[type="month"]::-webkit-calendar-picker-indicator {
+            filter: invert(1);
+        }
+
         .slider {
             width: 100%;
             height: 6px;


### PR DESCRIPTION
## Summary
- ensure calendar icon for forecast start month is white for better visibility

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68b78004134083288640deef85eb6d40