### PR TITLE
Remove unused TensorFlow script from dark theme

### DIFF
--- a/dark_sales_forecaster.html
+++ b/dark_sales_forecaster.html
@@ -9,7 +9,6 @@
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.10.0/dist/tf.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>
         * {


### PR DESCRIPTION
## Summary
- Clean up dark theme HTML by removing unused TensorFlow.js dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b7bba40a7083288adc62561d77056b