### PR TITLE
Add zoom controls to sales forecast chart

### DIFF
--- a/dark_sales_forecaster.css
+++ b/dark_sales_forecaster.css
@@ -249,6 +249,13 @@
             transform: translateY(-2px);
         }
 
+        .btn:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+            transform: none;
+            box-shadow: none;
+        }
+
         .btn-reset {
             background: rgba(245, 158, 11, 0.2);
             color: #fbbf24;
@@ -270,6 +277,23 @@
             border-radius: 0.75rem;
             padding: 1rem;
             border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .chart-inner {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+
+        .chart-inner canvas {
+            flex: 1;
+        }
+
+        .chart-toolbar {
+            display: flex;
+            justify-content: flex-end;
+            gap: 0.5rem;
+            margin-bottom: 0.5rem;
         }
 
         /* 테이블 */

--- a/dark_sales_forecaster.html
+++ b/dark_sales_forecaster.html
@@ -9,6 +9,7 @@
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.10.0/dist/tf.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="dark_sales_forecaster.css">

--- a/dark_sales_forecaster.js
+++ b/dark_sales_forecaster.js
@@ -1,5 +1,17 @@
         const { useState, useEffect, useMemo, useRef, useCallback } = React;
 
+        // Chart.js Zoom 플러그인 등록 (중복 등록 방지)
+        if (window.Chart && !window.__chartZoomPluginRegistered) {
+            const zoomPlugin =
+                window.ChartZoom ||
+                window.chartjsPluginZoom ||
+                window['chartjs-plugin-zoom'];
+            if (zoomPlugin) {
+                Chart.register(zoomPlugin);
+                window.__chartZoomPluginRegistered = true;
+            }
+        }
+
         // 토스트 알림 컴포넌트
         const Toast = ({ message, type, show, onClose }) => {
             useEffect(() => {
@@ -59,6 +71,12 @@
         const SalesChart = ({ data, predictions, showConfidenceInterval = true, isLoading = false }) => {
             const chartRef = useRef(null);
             const chartInstanceRef = useRef(null);
+
+            const handleResetZoom = useCallback(() => {
+                if (chartInstanceRef.current?.resetZoom) {
+                    chartInstanceRef.current.resetZoom();
+                }
+            }, []);
 
             useEffect(() => {
                 if (!chartRef.current || isLoading) return;
@@ -172,6 +190,31 @@
                                     usePointStyle: true,
                                     color: '#cbd5e1'
                                 }
+                            },
+                            zoom: {
+                                limits: {
+                                    x: { min: 'original', max: 'original' },
+                                    y: { min: 'original', max: 'original' }
+                                },
+                                pan: {
+                                    enabled: true,
+                                    mode: 'xy',
+                                    modifierKey: 'ctrl'
+                                },
+                                zoom: {
+                                    wheel: {
+                                        enabled: true
+                                    },
+                                    pinch: {
+                                        enabled: true
+                                    },
+                                    drag: {
+                                        enabled: true,
+                                        backgroundColor: 'rgba(59, 130, 246, 0.15)',
+                                        modifierKey: 'shift'
+                                    },
+                                    mode: 'xy'
+                                }
                             }
                         },
                         scales: {
@@ -229,7 +272,23 @@
                 return <LoadingSpinner message="차트 생성 중..." />;
             }
 
-            return <canvas ref={chartRef} />;
+            return (
+                <div className="chart-inner">
+                    <div className="chart-toolbar">
+                        <button
+                            type="button"
+                            className="btn btn-reset"
+                            onClick={handleResetZoom}
+                            disabled={isLoading}
+                            title="Shift 드래그 또는 마우스 휠로 확대/축소, Ctrl+드래그로 이동"
+                        >
+                            <i className="fas fa-search-minus"></i>
+                            줌 초기화
+                        </button>
+                    </div>
+                    <canvas ref={chartRef} style={{ flex: 1 }} />
+                </div>
+            );
         };
 
         // 메인 앱 컴포넌트


### PR DESCRIPTION
## Summary
- load the Chart.js zoom plugin and register it once for the dashboard
- enable wheel, pinch and drag zooming with a reset button on the sales chart
- add supporting styles for the new toolbar and button states

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_b_68ca7b855c648328b7588eb5ab87669e