### PR TITLE
Add background runner script and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+logs/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,30 @@ python app.py
 http://localhost:5173
 ```
 
+## ♻️ 백그라운드 실행 스크립트
+
+서버가 중단되더라도 자동으로 재시작되도록 유지하려면, 저장소 루트에 있는 `run_app_background.sh` 스크립트를 활용하세요. 기본적으로 `python app.py` 명령을 실행하며, 로그와 PID 정보는 `logs/` 디렉터리에 저장됩니다.
+
+```bash
+# 백그라운드 실행 시작
+./run_app_background.sh start
+
+# 상태 확인
+./run_app_background.sh status
+
+# 로그 확인
+./run_app_background.sh logs
+
+# 백그라운드 실행 중지
+./run_app_background.sh stop
+```
+
+필요에 따라 환경 변수를 통해 동작을 조정할 수 있습니다. 예를 들어 로그 디렉터리와 재시작 대기 시간을 바꾸고 싶다면 다음과 같이 실행합니다.
+
+```bash
+LOG_DIR=custom_logs RESTART_DELAY=10 ./run_app_background.sh start
+```
+
 ## 📘 사용 가이드
 
 1. 서버를 실행한 후 브라우저에서 `http://localhost:5173`에 접속합니다.

--- a/run_app_background.sh
+++ b/run_app_background.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_COMMAND=${APP_COMMAND:-"python app.py"}
+LOG_DIR=${LOG_DIR:-"logs"}
+PID_FILE="$LOG_DIR/app_background.pid"
+RUNNER_LOG="$LOG_DIR/background_runner.log"
+APP_LOG="$LOG_DIR/app_stdout.log"
+RESTART_DELAY=${RESTART_DELAY:-5}
+current_child_pid=0
+
+ensure_log_dir() {
+  mkdir -p "$LOG_DIR"
+}
+
+handle_exit() {
+  local ts
+  ts=$(date "+%Y-%m-%d %H:%M:%S%z")
+  echo "[$ts] Background runner received termination signal. Shutting down."
+  if [[ ${current_child_pid:-0} -ne 0 ]]; then
+    if kill -0 "$current_child_pid" 2>/dev/null; then
+      kill -- -"$current_child_pid" 2>/dev/null || true
+      wait "$current_child_pid" 2>/dev/null || true
+    fi
+    current_child_pid=0
+  fi
+  rm -f "$PID_FILE"
+  exit 0
+}
+
+is_running() {
+  if [[ -f "$PID_FILE" ]]; then
+    local pid
+    pid=$(<"$PID_FILE")
+    if kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+start_runner() {
+  ensure_log_dir
+  if is_running; then
+    echo "Background runner is already active (PID $(cat "$PID_FILE"))."
+    echo "Use '$0 status' to check its status or '$0 stop' to stop it first."
+    return 0
+  fi
+
+  touch "$RUNNER_LOG" "$APP_LOG"
+  nohup "$0" __run_loop >>"$RUNNER_LOG" 2>&1 &
+  local pid=$!
+  echo "$pid" >"$PID_FILE"
+  if command -v disown >/dev/null 2>&1; then
+    disown "$pid" 2>/dev/null || true
+  fi
+  echo "Started background runner (PID $pid)."
+  echo "Runner log: $RUNNER_LOG"
+  echo "Application log: $APP_LOG"
+}
+
+stop_runner() {
+  if ! [[ -f "$PID_FILE" ]]; then
+    echo "No PID file found. The background runner does not appear to be running."
+    return 0
+  fi
+
+  local pid
+  pid=$(<"$PID_FILE")
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid"
+    echo "Sent SIGTERM to background runner (PID $pid)."
+  else
+    echo "PID file existed but process $pid is not running. Cleaning up PID file."
+  fi
+  rm -f "$PID_FILE"
+}
+
+runner_status() {
+  if is_running; then
+    echo "Background runner is active (PID $(cat "$PID_FILE"))."
+    echo "Runner log: $RUNNER_LOG"
+    echo "Application log: $APP_LOG"
+  else
+    echo "Background runner is not running."
+  fi
+}
+
+show_logs() {
+  ensure_log_dir
+  echo "Runner log (tail -n 20):"
+  tail -n 20 "$RUNNER_LOG" 2>/dev/null || echo "No runner log yet."
+  echo
+  echo "Application log (tail -n 20):"
+  tail -n 20 "$APP_LOG" 2>/dev/null || echo "No application log yet."
+}
+
+run_loop() {
+  ensure_log_dir
+  trap handle_exit SIGTERM SIGINT
+  while true; do
+    local start_ts
+    start_ts=$(date "+%Y-%m-%d %H:%M:%S%z")
+    echo "[$start_ts] Starting background command: $APP_COMMAND"
+    set +e
+    setsid bash -c "$APP_COMMAND" >>"$APP_LOG" 2>&1 &
+    current_child_pid=$!
+    wait "$current_child_pid"
+    local exit_code=$?
+    current_child_pid=0
+    set -e
+    local end_ts
+    end_ts=$(date "+%Y-%m-%d %H:%M:%S%z")
+    echo "[$end_ts] Command exited with status $exit_code. Restarting in ${RESTART_DELAY}s."
+    sleep "$RESTART_DELAY"
+  done
+}
+
+usage() {
+  cat <<USAGE
+Usage: $0 <command>
+
+Commands:
+  start   Start the background runner that keeps the app alive.
+  stop    Stop the background runner.
+  status  Print whether the runner is active.
+  logs    Show the latest runner and application logs.
+
+Environment variables:
+  APP_COMMAND   Command to execute (default: "python app.py").
+  LOG_DIR       Directory to store logs and PID file (default: "logs").
+  RESTART_DELAY Seconds to wait before restarting the command (default: 5).
+USAGE
+}
+
+case "${1:-}" in
+  start)
+    start_runner
+    ;;
+  stop)
+    stop_runner
+    ;;
+  status)
+    runner_status
+    ;;
+  logs)
+    show_logs
+    ;;
+  __run_loop)
+    run_loop
+    ;;
+  *)
+    usage
+    if [[ "${1:-}" != "" ]]; then
+      exit 1
+    fi
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add a background runner script that restarts the Flask app, keeps logs, and handles signals cleanly
- document how to use and customize the background script in the README
- ignore the generated logs directory in version control

## Testing
- ./run_app_background.sh start
- ./run_app_background.sh status
- ./run_app_background.sh stop

------
https://chatgpt.com/codex/tasks/task_b_68ca8ca9d4f88328a491703a153ea182